### PR TITLE
[Fix] Review, Notice inconsistency, and uneven photo card.

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -855,7 +855,7 @@
 /* Enhanced Preview Image */
 .cpg-preview-wrapper img {
   max-width: 100%;
-  max-height: 280px;
+  max-height: 200px;
   width: auto;
   height: auto;
   object-fit: cover;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -2132,11 +2132,8 @@ body.wpcpg-modal-open {
 
 /* ====== SETUP NOTICE STYLING ====== */
 .cpg-setup-notice-wrapper {
-    margin-top: 40px;
-    margin-right: 20px;
-    /* padding: 0 20px;
-    position: relative;
-    z-index: 999999; */
+    margin: 5px 15px 2px;
+    padding: 1px 0;
 }
 
 .cpg-setup-notice {
@@ -2156,13 +2153,6 @@ body.wpcpg-modal-open {
     visibility: visible !important;
 }
 
-/* Debug: Force notice to be visible */
-/* .cpg-setup-notice-wrapper {
-    display: block !important;
-    visibility: visible !important;
-    opacity: 1 !important;
-} */
-
 /* Ensure notices appear in the right location */
 .wp-header-end + .cpg-setup-notice-wrapper,
 .wp-header-end + .cpg-shortcode-notice-wrapper {
@@ -2178,8 +2168,8 @@ body.wpcpg-modal-open {
 .cpg-setup-notice-content {
     display: flex;
     align-items: center;
-    padding: 12px 16px;
-    gap: 16px;
+    padding: 12px;
+    gap: 14px;
 }
 
 .cpg-setup-notice-icon {
@@ -2262,8 +2252,8 @@ body.wpcpg-modal-open {
 
 /* ====== SHORTCODE NOTICE STYLING ====== */
 .cpg-shortcode-notice-wrapper {
-    margin: 20px 0;
-    padding: 0 20px;
+    margin: 5px 15px 2px;
+    padding: 1px 0;
 }
 
 .cpg-shortcode-notice {
@@ -2283,8 +2273,8 @@ body.wpcpg-modal-open {
 .cpg-shortcode-notice-content {
     display: flex;
     align-items: center;
-    padding: 12px 16px;
-    gap: 16px;
+    padding: 12px;
+    gap: 14px;
 }
 
 .cpg-shortcode-notice-icon {

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,3 +1,8 @@
+/* Contributor Photo Gallery — frontend.css
+   Adjustments: refined circle/card visuals and caption typography for a cleaner, modern look.
+   Only circle-related rules and caption text styles were updated; other styles preserved.
+*/
+
 /* ====== BASE GALLERY GRID ====== */
 .cpg-gallery-grid {
     display: grid;
@@ -49,11 +54,15 @@
 }
 
 .cpg-photo-card.cpg-style-polaroid .cpg-photo-content p {
-    /* keep playful look but avoid Comic Sans fallback — use a neutral sans-serif */
-    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    font-size: 12px;
-    color: #333;
+    font-family: "Courier New", Courier, monospace;
+    font-size: 13px;
+    color: #222;
     margin: 0;
+    line-height: 1.4;
+    letter-spacing: 0.4px;
+    text-align: left; /* typewriter vibe feels more natural left aligned */
+	 text-shadow: 0.5px 0.8px 0 rgba(0,0,0,0.05);
+    opacity: 0.96;
 }
 
 /* ====== ENHANCED CIRCLE STYLE (REFINED) ====== */

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,8 +1,3 @@
-/* Contributor Photo Gallery — frontend.css
-   Adjustments: refined circle/card visuals and caption typography for a cleaner, modern look.
-   Only circle-related rules and caption text styles were updated; other styles preserved.
-*/
-
 /* ====== BASE GALLERY GRID ====== */
 .cpg-gallery-grid {
     display: grid;
@@ -409,4 +404,70 @@
     .cpg-range-value {
         align-self: flex-end;
     }
+}
+
+/* ===== FIX: lock image frames for all NON-circle cards, keep current look ===== */
+
+/* 1) Make the wrapper define the frame (so every upload crops consistently) */
+.cpg-photo-card:not(.cpg-style-circle) .cpg-photo-image {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 3 / 3;          /* matches your current ratio comment */
+    overflow: hidden;              /* ensures rounded corners actually clip */
+  }
+  
+  /* 2) Make the image fill that frame without distortion */
+  .cpg-photo-card:not(.cpg-style-circle) .cpg-photo-image img {
+    position: absolute;
+    inset: 0;                      /* top/right/bottom/left: 0 */
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+  }
+  
+  /* 3) Polaroid-specific: keep your rounded image corners while using the wrapper frame */
+  .cpg-photo-card.cpg-style-polaroid .cpg-photo-image {
+    aspect-ratio: 3 / 3;           /* same visual as before */
+    margin-bottom: 8px;            /* keep your spacing */
+  }
+  .cpg-photo-card.cpg-style-polaroid .cpg-photo-image img {
+  }
+  
+  /* 4) Circle guard: ensure nothing above affects circles */
+  .cpg-photo-card.cpg-style-circle .cpg-photo-image {
+    aspect-ratio: 1 / 1 !important;
+    overflow: hidden;
+  }
+
+/* Base: make "fixed" style fluid */
+.cpg-photo-card.cpg-style-fixed .cpg-photo-image {
+  width: 100%;
+  aspect-ratio: var(--cpg-fixed-ratio, 4 / 3);
+  height: auto !important;
+  position: relative;
+  overflow: hidden;
+}
+.cpg-photo-card.cpg-style-fixed .cpg-photo-image img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+/* Tune the ratio by column density */
+.cpg-gallery-grid.columns-1 .cpg-photo-card.cpg-style-fixed .cpg-photo-image { --cpg-fixed-ratio: 16 / 9; }
+.cpg-gallery-grid.columns-2 .cpg-photo-card.cpg-style-fixed .cpg-photo-image { --cpg-fixed-ratio: 4 / 3; }
+.cpg-gallery-grid.columns-3 .cpg-photo-card.cpg-style-fixed .cpg-photo-image { --cpg-fixed-ratio: 4 / 3; }
+.cpg-gallery-grid.columns-4 .cpg-photo-card.cpg-style-fixed .cpg-photo-image { --cpg-fixed-ratio: 3 / 2; }
+.cpg-gallery-grid.columns-6 .cpg-photo-card.cpg-style-fixed .cpg-photo-image { --cpg-fixed-ratio: 1 / 1; }
+
+/* Safety: remove legacy small-screen heights */
+@media (max-width: 768px),
+       (max-width: 480px) {
+  .cpg-photo-card.cpg-style-fixed .cpg-photo-image { 
+	  height: auto !important; 
+		   }
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -18,9 +18,9 @@
   });
 
   // Debug toggle (false in production)
-  var CPG_DEBUG = false;
+  var cpglry_DEBUG = false;
   function cpgLog() {
-    if (CPG_DEBUG && window.console) console.log.apply(console, arguments);
+    if (cpglry_DEBUG && window.console) console.log.apply(console, arguments);
   }
 
   // Debounce helper for preview requests
@@ -113,7 +113,7 @@
       });
 
       $.post(wpcpgAdmin.ajaxurl, {
-        action: "cpg_dismiss_new_shortcode_notice",
+        action: "cpglry_dismiss_new_shortcode_notice",
         nonce: wpcpgAdmin.nonce,
       });
     });
@@ -262,7 +262,7 @@
       $.post(
         wpcpgAdmin.ajaxurl,
         {
-          action: "wpcpg_clear_cache",
+          action: "wpcpglry_clear_cache",
           nonce: wpcpgAdmin.nonce,
         },
         function (resp) {
@@ -319,7 +319,7 @@
         $target.text(value);
         $hiddenInput.val(value);
         // Trigger preview update for photos per page changes
-        if ($(this).attr("id") === "cpg_per_page") {
+        if ($(this).attr("id") === "cpglry_per_page") {
           requestPreview();
         }
       });
@@ -454,7 +454,7 @@
     $.post(
       wpcpgAdmin.ajaxurl,
       {
-        action: "cpg_refresh_preview",
+        action: "cpglry_refresh_preview",
         settings: formData,
         nonce: wpcpgAdmin.nonce,
       },
@@ -495,7 +495,7 @@
           $(this).remove();
         });
         $.post(wpcpgAdmin.ajaxurl, {
-          action: "cpg_dismiss_shortcode_notice",
+          action: "cpglry_dismiss_shortcode_notice",
           nonce: wpcpgAdmin.nonce,
         });
       }
@@ -574,7 +574,7 @@
             url: "<?php echo esc_js( admin_url( 'admin-ajax.php' ) ); ?>",
             type: "POST",
             data: {
-                action: "cpg_dismiss_setup_notice",
+                action: "cpglry_dismiss_setup_notice",
                 nonce: $notice.data('cpg-nonce') || ""
             }
         });
@@ -590,7 +590,7 @@
             url: "<?php echo esc_js( admin_url( 'admin-ajax.php' ) ); ?>",
             type: "POST",
             data: {
-                action: $wrap.data('cpg-action') || 'cpg_dismiss_setup_notice',
+                action: $wrap.data('cpg-action') || 'cpglry_dismiss_setup_notice',
                 nonce: $wrap.data('cpg-nonce') || ''
             }
         });

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Shows a one-time settings-page "new shortcode" notice
  * - Provides AJAX handlers to persist dismissals
  */
-class cpglry_Admin {
+class CPGLRY_Admin {
 
 	private $options;
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -16,12 +16,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Shows a one-time settings-page "new shortcode" notice
  * - Provides AJAX handlers to persist dismissals
  */
-class CPG_Admin {
+class cpglry_Admin {
 
 	private $options;
 
 	public function __construct() {
-		$this->options = cpg_get_plugin_options();
+		$this->options = cpglry_get_plugin_options();
 
 		add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
@@ -36,9 +36,9 @@ class CPG_Admin {
 		add_action( 'admin_notices', array( $this, 'maybe_show_shortcode_notice' ) );
 
 		// AJAX handlers for dismissible notices
-		add_action( 'wp_ajax_cpg_dismiss_new_shortcode_notice', array( $this, 'ajax_dismiss_new_shortcode_notice' ) );
-		add_action( 'wp_ajax_cpg_dismiss_setup_notice', array( $this, 'ajax_dismiss_setup_notice' ) );
-		add_action( 'wp_ajax_cpg_dismiss_shortcode_notice', array( $this, 'ajax_dismiss_shortcode_notice' ) );
+		add_action( 'wp_ajax_cpglry_dismiss_new_shortcode_notice', array( $this, 'ajax_dismiss_new_shortcode_notice' ) );
+		add_action( 'wp_ajax_cpglry_dismiss_setup_notice', array( $this, 'ajax_dismiss_setup_notice' ) );
+		add_action( 'wp_ajax_cpglry_dismiss_shortcode_notice', array( $this, 'ajax_dismiss_shortcode_notice' ) );
 	}
 
 	/**
@@ -82,11 +82,11 @@ class CPG_Admin {
 	 * Register settings, sections and fields
 	 */
 	public function admin_init() {
-		register_setting( 'cpg_settings', 'cpg_options', array( 'sanitize_callback' => array( $this, 'validate_options' ) ) );
+		register_setting( 'cpglry_settings', 'cpglry_options', array( 'sanitize_callback' => array( $this, 'validate_options' ) ) );
 
-		add_settings_section( 'cpg_main', esc_html__( 'Essential Configuration', 'contributor-photo-gallery' ), array( $this, 'settings_section_callback' ), 'contributor-photo-gallery' );
-		add_settings_section( 'cpg_styling', esc_html__( 'Card Styling & Appearance', 'contributor-photo-gallery' ), array( $this, 'styling_settings_section_callback' ), 'contributor-photo-gallery' );
-		add_settings_section( 'cpg_advanced', esc_html__( 'Display & Performance', 'contributor-photo-gallery' ), array( $this, 'advanced_settings_section_callback' ), 'contributor-photo-gallery' );
+		add_settings_section( 'cpglry_main', esc_html__( 'Essential Configuration', 'contributor-photo-gallery' ), array( $this, 'settings_section_callback' ), 'contributor-photo-gallery' );
+		add_settings_section( 'cpglry_styling', esc_html__( 'Card Styling & Appearance', 'contributor-photo-gallery' ), array( $this, 'styling_settings_section_callback' ), 'contributor-photo-gallery' );
+		add_settings_section( 'cpglry_advanced', esc_html__( 'Display & Performance', 'contributor-photo-gallery' ), array( $this, 'advanced_settings_section_callback' ), 'contributor-photo-gallery' );
 
 		$this->add_settings_fields();
 	}
@@ -109,7 +109,7 @@ class CPG_Admin {
 			'wpcpgAdmin',
 			array(
 				'ajaxurl' => admin_url( 'admin-ajax.php' ),
-				'nonce'   => wp_create_nonce( 'wpcpg_admin_nonce' ),
+				'nonce'   => wp_create_nonce( 'wpcpglry_admin_nonce' ),
 			)
 		);
 	}
@@ -118,9 +118,9 @@ class CPG_Admin {
 	 * Show setup notice if user ID is not configured
 	 */
 	public function maybe_show_setup_notice() {
-		$options   = cpg_get_plugin_options();
+		$options   = cpglry_get_plugin_options();
 		$user_id   = isset( $options['default_user_id'] ) ? $options['default_user_id'] : '';
-		$dismissed = get_option( 'cpg_setup_notice_dismissed', 0 );
+		$dismissed = get_option( 'cpglry_setup_notice_dismissed', 0 );
 
 		// Already configured or dismissed → don't show
 		if ( ! empty( $user_id ) || $dismissed ) {
@@ -129,13 +129,13 @@ class CPG_Admin {
 
     $is_settings_page = isset( $_GET['page'] ) && $_GET['page'] === 'contributor-photo-gallery'; // phpcs:ignore
 		$settings_url = esc_url( admin_url( 'admin.php?page=contributor-photo-gallery' ) );
-		$nonce        = wp_create_nonce( 'cpg_setup_nonce' );
+		$nonce        = wp_create_nonce( 'cpglry_setup_nonce' );
 
 		if ( $is_settings_page ) :
 			// --- Your original pretty card (unchanged) — only on Settings page ---
 			?>
 		<div class="cpg-setup-notice-wrapper">
-			<div class="cpg-setup-notice" data-cpg-nonce="<?php echo esc_attr( $nonce ); ?>" data-cpg-action="cpg_dismiss_setup_notice">
+			<div class="cpg-setup-notice" data-cpg-nonce="<?php echo esc_attr( $nonce ); ?>" data-cpg-action="cpglry_dismiss_setup_notice">
 				<div class="cpg-setup-notice-content">
 					<div class="cpg-setup-notice-icon">
 						<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -159,7 +159,7 @@ class CPG_Admin {
 		// --- Core WP notice everywhere else (Dashboard, Plugins, etc.) ---
 		?>
 		<div class="notice notice-info is-dismissible cpg-setup-core"
-			data-cpg-action="cpg_dismiss_setup_notice"
+			data-cpg-action="cpglry_dismiss_setup_notice"
 			data-cpg-nonce="<?php echo esc_attr( $nonce ); ?>">
 			<p>
 				<strong><?php esc_html_e( 'Contributor Photo Gallery', 'contributor-photo-gallery' ); ?>:</strong>
@@ -184,14 +184,14 @@ class CPG_Admin {
 		}
 
 		// Check if user has dismissed this notice
-		$dismissed = get_option( 'cpg_shortcode_notice_dismissed', 0 );
+		$dismissed = get_option( 'cpglry_shortcode_notice_dismissed', 0 );
 		if ( $dismissed ) {
 			return;
 		}
 
 		?>
 		<div class="cpg-shortcode-notice-wrapper">
-			<div class="cpg-shortcode-notice" data-cpg-action="cpg_dismiss_shortcode_notice">
+			<div class="cpg-shortcode-notice" data-cpg-action="cpglry_dismiss_shortcode_notice">
 				<div class="cpg-shortcode-notice-content">
 					<div class="cpg-shortcode-notice-icon">
 						<span class="dashicons dashicons-shortcode"></span>
@@ -220,62 +220,62 @@ class CPG_Admin {
 			'default_user_id'     => array(
 				'title'    => esc_html__( 'User ID', 'contributor-photo-gallery' ),
 				'callback' => array( $this, 'user_id_field_callback' ),
-				'section'  => 'cpg_main',
+				'section'  => 'cpglry_main',
 			),
 			'default_per_page'    => array(
 				'title'    => esc_html__( 'Photos Per Page', 'contributor-photo-gallery' ),
 				'callback' => array( $this, 'per_page_field_callback' ),
-				'section'  => 'cpg_main',
+				'section'  => 'cpglry_main',
 			),
 			'default_columns'     => array(
 				'title'    => esc_html__( 'Grid Layout', 'contributor-photo-gallery' ),
 				'callback' => array( $this, 'columns_field_callback' ),
-				'section'  => 'cpg_main',
+				'section'  => 'cpglry_main',
 			),
 			'card_style'          => array(
 				'title'    => '',
 				'callback' => array( $this, 'card_style_field_callback' ),
-				'section'  => 'cpg_styling',
+				'section'  => 'cpglry_styling',
 			),
 			'card_bg_color'       => array(
 				'title'    => '',
 				'callback' => array( $this, 'card_bg_color_field_callback' ),
-				'section'  => 'cpg_styling',
+				'section'  => 'cpglry_styling',
 			),
 			'card_border_style'   => array(
 				'title'    => '',
 				'callback' => array( $this, 'card_border_style_field_callback' ),
-				'section'  => 'cpg_styling',
+				'section'  => 'cpglry_styling',
 			),
 			'card_shadow_style'   => array(
 				'title'    => '',
 				'callback' => array( $this, 'card_shadow_style_field_callback' ),
-				'section'  => 'cpg_styling',
+				'section'  => 'cpglry_styling',
 			),
 			'show_captions'       => array(
 				'title'    => '',
 				'callback' => array( $this, 'show_captions_field_callback' ),
-				'section'  => 'cpg_styling',
+				'section'  => 'cpglry_styling',
 			),
 			'caption_text_color'  => array(
 				'title'    => '',
 				'callback' => array( $this, 'caption_text_color_field_callback' ),
-				'section'  => 'cpg_styling',
+				'section'  => 'cpglry_styling',
 			),
 			'cache_time'          => array(
 				'title'    => esc_html__( 'Cache Duration', 'contributor-photo-gallery' ),
 				'callback' => array( $this, 'cache_time_field_callback' ),
-				'section'  => 'cpg_advanced',
+				'section'  => 'cpglry_advanced',
 			),
 			'open_in_new_tab'     => array(
 				'title'    => esc_html__( 'Link Behavior', 'contributor-photo-gallery' ),
 				'callback' => array( $this, 'new_tab_field_callback' ),
-				'section'  => 'cpg_advanced',
+				'section'  => 'cpglry_advanced',
 			),
 			'enable_lazy_loading' => array(
 				'title'    => esc_html__( 'Lazy Loading', 'contributor-photo-gallery' ),
 				'callback' => array( $this, 'lazy_loading_field_callback' ),
-				'section'  => 'cpg_advanced',
+				'section'  => 'cpglry_advanced',
 			),
 		);
 
@@ -310,7 +310,7 @@ class CPG_Admin {
 		?>
 		<div class="cpg-field-container">
 			<div class="cpg-input-group">
-				<input type="text" id="default_user_id" name="cpg_options[default_user_id]" value="<?php echo esc_attr( $user_id ); ?>" class="cpg-input-field" placeholder="<?php esc_attr_e( 'e.g., 21053005', 'contributor-photo-gallery' ); ?>" />
+				<input type="text" id="default_user_id" name="cpglry_options[default_user_id]" value="<?php echo esc_attr( $user_id ); ?>" class="cpg-input-field" placeholder="<?php esc_attr_e( 'e.g., 21053005', 'contributor-photo-gallery' ); ?>" />
 				<button type="button" id="user-id-help-btn" class="cpg-help-btn" title="<?php esc_attr_e( 'How to find your User ID', 'contributor-photo-gallery' ); ?>">?</button>
 			</div>
 			<div id="user-id-status" class="cpg-field-status"></div>
@@ -332,7 +332,7 @@ class CPG_Admin {
 					<span id="per_page_display"><?php echo esc_html( $per_page ); ?></span> <?php esc_html_e( 'photos', 'contributor-photo-gallery' ); ?>
 				</div>
 			</div>
-			<input type="hidden" id="default_per_page" name="cpg_options[default_per_page]" value="<?php echo esc_attr( $per_page ); ?>" />
+			<input type="hidden" id="default_per_page" name="cpglry_options[default_per_page]" value="<?php echo esc_attr( $per_page ); ?>" />
 			<p class="cpg-field-desc">
 				<?php esc_html_e( 'Number of photos to display per gallery page.', 'contributor-photo-gallery' ); ?>
 			</p>
@@ -373,7 +373,7 @@ class CPG_Admin {
 			<div class="cpg-columns-grid">
 				<?php foreach ( $column_options as $value => $option ) : ?>
 					<label class="cpg-column-option <?php echo $columns == $value ? 'selected' : ''; ?>" data-value="<?php echo esc_attr( $value ); ?>">
-						<input type="radio" name="cpg_options[default_columns]" value="<?php echo esc_attr( $value ); ?>" <?php checked( $columns, $value ); ?> class="cpg-column-radio" />
+						<input type="radio" name="cpglry_options[default_columns]" value="<?php echo esc_attr( $value ); ?>" <?php checked( $columns, $value ); ?> class="cpg-column-radio" />
 						<div class="cpg-column-card">
 							<div class="cpg-column-label"><?php echo esc_html( $option['label'] ); ?></div>
 							<div class="cpg-column-desc"><?php echo esc_html( $option['desc'] ); ?></div>
@@ -414,7 +414,7 @@ class CPG_Admin {
 			<div class="cpg-style-grid">
 				<?php foreach ( $style_options as $value => $option ) : ?>
 					<label class="cpg-style-option <?php echo $card_style == $value ? 'selected' : ''; ?>">
-						<input type="radio" name="cpg_options[card_style]" value="<?php echo esc_attr( $value ); ?>" <?php checked( $card_style, $value ); ?> />
+						<input type="radio" name="cpglry_options[card_style]" value="<?php echo esc_attr( $value ); ?>" <?php checked( $card_style, $value ); ?> />
 						<div class="cpg-style-card cpg-style-<?php echo esc_attr( $value ); ?>">
 							<div class="cpg-style-preview"></div>
 							<div class="cpg-style-label"><?php echo esc_html( $option['label'] ); ?></div>
@@ -434,7 +434,7 @@ class CPG_Admin {
 		<label class="cpg-label"><?php esc_html_e( 'Background Color', 'contributor-photo-gallery' ); ?></label>
 		<div class="cpg-field-container">
 			<div class="cpg-color-group">
-				<input type="color" id="card_bg_color" name="cpg_options[card_bg_color]" value="<?php echo esc_attr( $bg_color ); ?>" class="cpg-color-picker" />
+				<input type="color" id="card_bg_color" name="cpglry_options[card_bg_color]" value="<?php echo esc_attr( $bg_color ); ?>" class="cpg-color-picker" />
 				<input type="text" id="card_bg_color_text" value="<?php echo esc_attr( $bg_color ); ?>" class="cpg-color-text" placeholder="#ffffff" />
 				<button type="button" class="cpg-color-reset" data-default="#ffffff"><?php esc_html_e( 'Reset', 'contributor-photo-gallery' ); ?></button>
 			</div>
@@ -453,7 +453,7 @@ class CPG_Admin {
 			<div class="cpg-border-controls">
 				<div class="cpg-border-row">
 					<label class="cpg-control-label"><?php esc_html_e( 'Style', 'contributor-photo-gallery' ); ?></label>
-					<select name="cpg_options[card_border_style]" class="cpg-select-field">
+					<select name="cpglry_options[card_border_style]" class="cpg-select-field">
 						<option value="none" <?php selected( $border_style, 'none' ); ?>><?php esc_html_e( 'None', 'contributor-photo-gallery' ); ?></option>
 						<option value="solid" <?php selected( $border_style, 'solid' ); ?>><?php esc_html_e( 'Solid', 'contributor-photo-gallery' ); ?></option>
 						<option value="dashed" <?php selected( $border_style, 'dashed' ); ?>><?php esc_html_e( 'Dashed', 'contributor-photo-gallery' ); ?></option>
@@ -463,13 +463,13 @@ class CPG_Admin {
 				<div class="cpg-border-row">
 					<label class="cpg-control-label"><?php esc_html_e( 'Width', 'contributor-photo-gallery' ); ?></label>
 					<div class="cpg-number-input-group">
-						<input type="number" name="cpg_options[card_border_width]" min="0" max="10" value="<?php echo esc_attr( $border_width ); ?>" class="cpg-number-input" />
+						<input type="number" name="cpglry_options[card_border_width]" min="0" max="10" value="<?php echo esc_attr( $border_width ); ?>" class="cpg-number-input" />
 						<span class="cpg-input-suffix">px</span>
 					</div>
 				</div>
 				<div class="cpg-border-row">
 					<label class="cpg-control-label"><?php esc_html_e( 'Color', 'contributor-photo-gallery' ); ?></label>
-					<input type="color" name="cpg_options[card_border_color]" value="<?php echo esc_attr( $border_color ); ?>" class="cpg-color-picker cpg-border-color-picker" />
+					<input type="color" name="cpglry_options[card_border_color]" value="<?php echo esc_attr( $border_color ); ?>" class="cpg-color-picker cpg-border-color-picker" />
 				</div>
 			</div>
 			<p class="cpg-field-desc"><?php esc_html_e( 'Customize border appearance of cards.', 'contributor-photo-gallery' ); ?></p>
@@ -506,7 +506,7 @@ class CPG_Admin {
 				foreach ( $shadow_options as $value => $option ) :
 					?>
 					<label class="cpg-shadow-option cpg-shadow-<?php echo esc_attr( $value ); ?> <?php echo $shadow_style === $value ? 'selected' : ''; ?>">
-						<input type="radio" name="cpg_options[card_shadow_style]" value="<?php echo esc_attr( $value ); ?>" <?php checked( $shadow_style, $value ); ?> />
+						<input type="radio" name="cpglry_options[card_shadow_style]" value="<?php echo esc_attr( $value ); ?>" <?php checked( $shadow_style, $value ); ?> />
 						<div class="cpg-shadow-chip"></div>
 						<div class="cpg-shadow-info">
 							<span class="cpg-shadow-label"><?php echo esc_html( $option['label'] ); ?></span>
@@ -533,9 +533,9 @@ class CPG_Admin {
 		?>
 		<label class="cpg-label"><?php esc_html_e( 'Photo Captions', 'contributor-photo-gallery' ); ?></label>
 		<div class="cpg-field-container">
-			<input type="hidden" name="cpg_options[show_captions]" value="0" />
+			<input type="hidden" name="cpglry_options[show_captions]" value="0" />
 			<label class="cpg-toggle-container">
-				<input type="checkbox" id="show_captions" name="cpg_options[show_captions]" value="1" <?php checked( $show_captions, 1 ); ?> />
+				<input type="checkbox" id="show_captions" name="cpglry_options[show_captions]" value="1" <?php checked( $show_captions, 1 ); ?> />
 				<span class="cpg-toggle-slider"></span>
 				<span class="cpg-toggle-label"><?php esc_html_e( 'Display captions on cards', 'contributor-photo-gallery' ); ?></span>
 			</label>
@@ -550,7 +550,7 @@ class CPG_Admin {
 		<label class="cpg-label"><?php esc_html_e( 'Caption Text Color', 'contributor-photo-gallery' ); ?></label>
 		<div class="cpg-field-container">
 			<div class="cpg-color-group">
-				<input type="color" id="caption_text_color" name="cpg_options[caption_text_color]" value="<?php echo esc_attr( $color ); ?>" class="cpg-color-picker" />
+				<input type="color" id="caption_text_color" name="cpglry_options[caption_text_color]" value="<?php echo esc_attr( $color ); ?>" class="cpg-color-picker" />
 				<input type="text" id="caption_text_color_text" value="<?php echo esc_attr( $color ); ?>" class="cpg-color-text" />
 			</div>
 			<p class="cpg-field-desc"><?php esc_html_e( 'Customize caption font color for better contrast or branding.', 'contributor-photo-gallery' ); ?></p>
@@ -571,7 +571,7 @@ class CPG_Admin {
 		);
 		?>
 		<div class="cpg-field-container">
-			<select id="cache_time" name="cpg_options[cache_time]" class="cpg-select-field">
+			<select id="cache_time" name="cpglry_options[cache_time]" class="cpg-select-field">
 				<?php foreach ( $options as $value => $label ) : ?>
 					<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $cache_time, $value ); ?>><?php echo esc_html( $label ); ?></option>
 				<?php endforeach; ?>
@@ -585,9 +585,9 @@ class CPG_Admin {
 		$checked = isset( $this->options['open_in_new_tab'] ) ? $this->options['open_in_new_tab'] : 1;
 		?>
 		<div class="cpg-field-container">
-			<input type="hidden" name="cpg_options[open_in_new_tab]" value="0" />
+			<input type="hidden" name="cpglry_options[open_in_new_tab]" value="0" />
 			<label class="cpg-toggle-container">
-				<input type="checkbox" id="open_in_new_tab" name="cpg_options[open_in_new_tab]" value="1" <?php checked( $checked, 1 ); ?> />
+				<input type="checkbox" id="open_in_new_tab" name="cpglry_options[open_in_new_tab]" value="1" <?php checked( $checked, 1 ); ?> />
 				<span class="cpg-toggle-slider"></span>
 				<span class="cpg-toggle-label"><?php esc_html_e( 'Open links in new tab', 'contributor-photo-gallery' ); ?></span>
 			</label>
@@ -600,9 +600,9 @@ class CPG_Admin {
 		$checked = isset( $this->options['enable_lazy_loading'] ) ? $this->options['enable_lazy_loading'] : 1;
 		?>
 		<div class="cpg-field-container">
-			<input type="hidden" name="cpg_options[enable_lazy_loading]" value="0" />
+			<input type="hidden" name="cpglry_options[enable_lazy_loading]" value="0" />
 			<label class="cpg-toggle-container">
-				<input type="checkbox" id="enable_lazy_loading" name="cpg_options[enable_lazy_loading]" value="1" <?php checked( $checked, 1 ); ?> />
+				<input type="checkbox" id="enable_lazy_loading" name="cpglry_options[enable_lazy_loading]" value="1" <?php checked( $checked, 1 ); ?> />
 				<span class="cpg-toggle-slider"></span>
 				<span class="cpg-toggle-label"><?php esc_html_e( 'Enable performance optimization', 'contributor-photo-gallery' ); ?></span>
 			</label>
@@ -617,7 +617,7 @@ class CPG_Admin {
 		------------------------- */
 	public function validate_options( $input ) {
 		if ( ! is_array( $input ) ) {
-			return cpg_get_default_options();
+			return cpglry_get_default_options();
 		}
 
 		$validated = array();
@@ -644,7 +644,7 @@ class CPG_Admin {
 		$validated['open_in_new_tab']     = ! empty( $input['open_in_new_tab'] ) ? 1 : 0;
 		$validated['enable_lazy_loading'] = ! empty( $input['enable_lazy_loading'] ) ? 1 : 0;
 
-		add_settings_error( 'cpg_options', 'settings_saved', esc_html__( 'Settings saved successfully!', 'contributor-photo-gallery' ), 'updated' );
+		add_settings_error( 'cpglry_options', 'settings_saved', esc_html__( 'Settings saved successfully!', 'contributor-photo-gallery' ), 'updated' );
 
 		// update local copy so the page reflects changes immediately after save
 		$this->options = $validated;
@@ -657,7 +657,7 @@ class CPG_Admin {
 	 */
 	public function settings_page() {
 		// Provide the notice flag to the template
-		$notice_shown = get_option( 'cpg_new_shortcode_notice_shown', 0 );
+		$notice_shown = get_option( 'cpglry_new_shortcode_notice_shown', 0 );
 		include CPGLRY_PLUGIN_PATH . 'templates/admin/settings-page.php';
 	}
 
@@ -665,13 +665,13 @@ class CPG_Admin {
 	 * AJAX: dismiss the one-time new-shortcode notice (settings-page notice)
 	 */
 	public function ajax_dismiss_new_shortcode_notice() {
-		check_ajax_referer( 'wpcpg_admin_nonce', 'nonce' );
+		check_ajax_referer( 'wpcpglry_admin_nonce', 'nonce' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( array( 'message' => 'Permission denied' ), 403 );
 		}
 
-		update_option( 'cpg_new_shortcode_notice_shown', 1 );
+		update_option( 'cpglry_new_shortcode_notice_shown', 1 );
 		wp_send_json_success( array( 'message' => 'Notice dismissed' ) );
 	}
 
@@ -679,14 +679,14 @@ class CPG_Admin {
 	 * AJAX: dismiss the site-wide setup notice
 	 */
 	public function ajax_dismiss_setup_notice() {
-		check_ajax_referer( 'cpg_setup_nonce', 'nonce' );
+		check_ajax_referer( 'cpglry_setup_nonce', 'nonce' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( array( 'message' => 'Permission denied' ), 403 );
 		}
 
 		// Persist dismissal globally (use update_user_meta if you prefer per-user)
-		update_option( 'cpg_setup_notice_dismissed', 1 );
+		update_option( 'cpglry_setup_notice_dismissed', 1 );
 		wp_send_json_success( array( 'message' => 'Setup notice dismissed' ) );
 	}
 
@@ -694,13 +694,13 @@ class CPG_Admin {
 	 * AJAX: dismiss the shortcode update notice
 	 */
 	public function ajax_dismiss_shortcode_notice() {
-		check_ajax_referer( 'wpcpg_admin_nonce', 'nonce' );
+		check_ajax_referer( 'wpcpglry_admin_nonce', 'nonce' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( array( 'message' => 'Permission denied' ), 403 );
 		}
 
-		update_option( 'cpg_shortcode_notice_dismissed', 1 );
+		update_option( 'cpglry_shortcode_notice_dismissed', 1 );
 		wp_send_json_success( array( 'message' => 'Shortcode notice dismissed' ) );
 	}
 }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -1,8 +1,8 @@
 <?php
-class CPG_API {
+class CPGLRY_API {
 
 	public static function get_photos( $user_id, $per_page, $cache_time ) {
-		$cache_key = 'cpg_photos_' . md5( $user_id . '_' . $per_page );
+		$cache_key = 'cpglry_photos_' . md5( $user_id . '_' . $per_page );
 		$photos    = get_transient( $cache_key );
 		if ( false !== $photos ) {
 			return $photos;

--- a/includes/class-cache.php
+++ b/includes/class-cache.php
@@ -1,11 +1,11 @@
 <?php
-class CPG_Cache {
+class CPGLRY_Cache {
 
 	public static function clear() {
 		global $wpdb;
 
 		// Use esc_like to build the LIKE pattern safely for the current DB prefix.
-		$like = $wpdb->esc_like( '_transient_cpg_photos_' ) . '%';
+		$like = $wpdb->esc_like( '_transient_cpglry_photos_' ) . '%';
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$transient_names = $wpdb->get_col(
@@ -20,7 +20,7 @@ class CPG_Cache {
 		}
 
 		foreach ( $transient_names as $transient_name ) {
-			// stored names are like "_transient_cpg_photos_<hash>"
+			// stored names are like "_transient_cpglry_photos_<hash>"
 			$name = str_replace( '_transient_', '', $transient_name );
 			delete_transient( $name );
 		}
@@ -29,10 +29,10 @@ class CPG_Cache {
 
 /**
  * Backwards-compatible procedural wrapper.
- * Some older code or external integrations might call cpg_clear_photo_cache().
+ * Some older code or external integrations might call cpglry_clear_photo_cache().
  */
-if ( ! function_exists( 'cpg_clear_photo_cache' ) ) {
-	function cpg_clear_photo_cache() {
-		CPG_Cache::clear();
+if ( ! function_exists( 'cpglry_clear_photo_cache' ) ) {
+	function cpglry_clear_photo_cache() {
+		cpglry_Cache::clear();
 	}
 }

--- a/includes/class-frontend.php
+++ b/includes/class-frontend.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-class CPG_Frontend {
+class CPGLRY_Frontend {
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
 	}
@@ -53,7 +53,7 @@ class CPG_Frontend {
 	 * Renders the gallery using templates/grid.php which expects $photos and $options.
 	 */
 	public static function render_shortcode( $atts = array() ) {
-		$options = cpg_get_plugin_options();
+		$options = cpglry_get_plugin_options();
 
 		// shortcode attrs override options
 		$atts = shortcode_atts(
@@ -75,7 +75,7 @@ class CPG_Frontend {
 			return '<div class="cpg-shortcode-error">Please configure a User ID in the plugin settings.</div>';
 		}
 
-		$photos = CPG_API::get_photos( $user_id, $per_page, $options['cache_time'] );
+		$photos = CPGLRY_API::get_photos( $user_id, $per_page, $options['cache_time'] );
 
 		if ( is_wp_error( $photos ) ) {
 			return '<div class="cpg-shortcode-error">' . esc_html( $photos->get_error_message() ) . '</div>';

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Default plugin options
  */
-function cpg_get_default_options() {
+function cpglry_get_default_options() {
 	return array(
 		'default_user_id'     => '',
 		'default_per_page'    => 12,
@@ -30,9 +30,9 @@ function cpg_get_default_options() {
 /**
  * Get current saved options (merges with defaults)
  */
-function cpg_get_plugin_options() {
-	$defaults = cpg_get_default_options();
-	$opts     = get_option( 'cpg_options', array() );
+function cpglry_get_plugin_options() {
+	$defaults = cpglry_get_default_options();
+	$opts     = get_option( 'cpglry_options', array() );
 	if ( ! is_array( $opts ) ) {
 		$opts = array();
 	}

--- a/templates/admin/settings-page.php
+++ b/templates/admin/settings-page.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$options             = cpg_get_plugin_options();
+$options             = cpglry_get_plugin_options();
 $user_id             = isset( $options['default_user_id'] ) ? $options['default_user_id'] : '';
 $per_page            = isset( $options['default_per_page'] ) ? $options['default_per_page'] : 12;
 $columns             = isset( $options['default_columns'] ) ? $options['default_columns'] : 4;
@@ -26,7 +26,7 @@ $enable_lazy_loading = ! empty( $options['enable_lazy_loading'] );
 		<!-- LEFT PANEL: Settings -->
 		<div class="cpg-settings-panel">
 			<form method="post" action="options.php" class="cpg-form">
-				<?php settings_fields( 'cpg_settings' ); ?>
+				<?php settings_fields( 'cpglry_settings' ); ?>
 
 				<!-- Essential Configuration Card -->
 				<div class="cpg-card">
@@ -36,7 +36,7 @@ $enable_lazy_loading = ! empty( $options['enable_lazy_loading'] );
 					</div>
 					<div class="cpg-card-content">
 						<?php
-						do_settings_fields( 'contributor-photo-gallery', 'cpg_main' );
+						do_settings_fields( 'contributor-photo-gallery', 'cpglry_main' );
 						?>
 					</div>
 				</div>
@@ -48,7 +48,7 @@ $enable_lazy_loading = ! empty( $options['enable_lazy_loading'] );
 						<p>Customize the appearance and styling of your photo cards.</p>
 					</div>
 					<div class="cpg-card-content">
-						<?php do_settings_fields( 'contributor-photo-gallery', 'cpg_styling' ); ?>
+						<?php do_settings_fields( 'contributor-photo-gallery', 'cpglry_styling' ); ?>
 					</div>
 				</div>
 
@@ -59,7 +59,7 @@ $enable_lazy_loading = ! empty( $options['enable_lazy_loading'] );
 						<p>Fine-tune performance and display preferences.</p>
 					</div>
 					<div class="cpg-card-content">
-						<?php do_settings_fields( 'contributor-photo-gallery', 'cpg_advanced' ); ?>
+						<?php do_settings_fields( 'contributor-photo-gallery', 'cpglry_advanced' ); ?>
 					</div>
 				</div>
 

--- a/templates/grid.php
+++ b/templates/grid.php
@@ -3,9 +3,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-// expects $photos, $options (fallback cpg_get_plugin_options), and $atts passed from renderer
+// expects $photos, $options (fallback cpglry_get_plugin_options), and $atts passed from renderer
 if ( ! isset( $options ) ) {
-	$options = cpg_get_plugin_options();
+	$options = cpglry_get_plugin_options();
 }
 if ( ! isset( $photos ) || ! is_array( $photos ) ) {
 	$photos = array();

--- a/uninstall.php
+++ b/uninstall.php
@@ -2,4 +2,4 @@
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
-delete_option( 'cpg_options' );
+delete_option( 'cpglry_options' );


### PR DESCRIPTION
## Summary

This PR fixes visual inconsistencies across the review notice and photo card components, and improves code clarity by replacing the short `cpg_` function prefix with the clearer `cpglry_`.

### Changes Made

- Adjusted `shortcode updated` & `setup` notice styles for consistent spacing, alignment, and typography. 
  Based on ideas from PR #19 by @sajid-ansari-65. Co-authored-by: Sajid Ansari <sajidansari0605@gmail.com>

- Fixed uneven photo card layouts by standardizing aspect ratios and ensuring images scale correctly within their frames.

- Cleaned up overlapping/stacking issues where images or pseudo elements could break alignment.

- Replaced `cpg_` function prefix with `cpglry_` to avoid conflicts and follow better naming conventions.

### Impact

- All photo card styles now render consistently with correct proportions.

- Review notices display with consistent styling and no visual misalignment.

- Improved maintainability and clarity with a longer, safer function prefix (`cpglry_`).

- Better cross-browser and cross-device reliability.

### Testing

- Verified on desktop (Chrome, Firefox, Safari) and mobile (Android, iOS).

- Checked default, polaroid, circle, and fixed card layouts in different grid configurations.

- Confirmed that review notices no longer show uneven padding or inconsistent text size.

- Verified that `cpglry_`-prefixed functions register shortcodes correctly and do not conflict.

## Fixes & PRs
- #21 
- #19 
- #17

## Credits
- @BhargavBhandari90 
- @sajid-ansari-65